### PR TITLE
Reduce cpu usage

### DIFF
--- a/src/waitpid.cc
+++ b/src/waitpid.cc
@@ -16,6 +16,7 @@ static Handle<Value> Waitpid(const Arguments& args) {
     child = args[0]->Int32Value();
 
     do {
+      usleep(1000);
       r = waitpid(child, &status, WNOHANG);
     } while (r != -1);
 


### PR DESCRIPTION
Before, it would max out a cpu core at 100% while waiting (undesirable if what it's waiting on needs the full cpu). Adding a 1ms sleep reduced its usage to about 1-2% in my case.
